### PR TITLE
feat: integrate multiplatform-settings for persistent storage

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -63,6 +63,7 @@ kotlin {
             implementation(libs.koin.android)
             implementation(libs.koin.androidx.compose)
             implementation(libs.ktor.client.okhttp)
+            implementation("androidx.preference:preference:1.2.0")
         }
         commonMain.dependencies {
             implementation(compose.runtime)
@@ -95,6 +96,8 @@ kotlin {
             implementation(libs.kotlinx.serialization.json)
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.kotlinx.collections.immutable)
+
+            implementation("com.russhwolf:multiplatform-settings:1.3.0")
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/composeApp/src/androidMain/kotlin/org/mytemplatewizard/project/di/Modules.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/mytemplatewizard/project/di/Modules.android.kt
@@ -1,0 +1,15 @@
+package org.mytemplatewizard.project.di
+
+import androidx.preference.PreferenceManager
+import com.russhwolf.settings.Settings
+import com.russhwolf.settings.SharedPreferencesSettings
+import org.koin.android.ext.koin.androidContext
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+actual val platformModule: Module = module {
+    single<Settings> {
+        val sharedPrefs = PreferenceManager.getDefaultSharedPreferences(androidContext())
+        SharedPreferencesSettings(sharedPrefs)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/mytemplatewizard/project/di/InitKoin.kt
+++ b/composeApp/src/commonMain/kotlin/org/mytemplatewizard/project/di/InitKoin.kt
@@ -8,7 +8,7 @@ fun initKoin(config: KoinAppDeclaration? = null) {
         config?.invoke(this)
         modules(
             sharedModule,
-//            platformModule,
+            platformModule,
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/mytemplatewizard/project/di/Modules.kt
+++ b/composeApp/src/commonMain/kotlin/org/mytemplatewizard/project/di/Modules.kt
@@ -7,6 +7,7 @@ import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
+import org.koin.core.module.Module
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
 import org.mytemplatewizard.project.repository.LoggerRepository
@@ -20,13 +21,13 @@ import org.mytemplatewizard.project.viewmodel.HomePaneViewModel
 import org.mytemplatewizard.project.viewmodel.HomeViewModel
 import org.mytemplatewizard.project.viewmodel.MainViewModel
 
-//expect val platformModule: Module
+expect val platformModule: Module
 
 val sharedModule = module {
 //    singleOf(::AlarmControlRepository)
 //    single<FirebaseDatabaseRepository> { FirebaseDatabaseRepositoryImpl() }
 //    single<DeviceActionRepository> { DeviceActionRepositoryImpl(get(), get(),get()) }
-    single<SampleRepository> { SampleRepositoryImpl() }
+    single<SampleRepository> { SampleRepositoryImpl(get()) }
     single<LoggerRepository> { LoggerRepositoryImpl() }
     single {
         HttpClient {

--- a/composeApp/src/commonMain/kotlin/org/mytemplatewizard/project/repository/SampleRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/mytemplatewizard/project/repository/SampleRepository.kt
@@ -5,4 +5,8 @@ import kotlinx.coroutines.flow.Flow
 
 interface SampleRepository {
     fun getIntFlow(): Flow<Int>
+
+    fun setSetting(value: String)
+    fun getSettings(): String
+
 }

--- a/composeApp/src/commonMain/kotlin/org/mytemplatewizard/project/repository/SampleRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/org/mytemplatewizard/project/repository/SampleRepositoryImpl.kt
@@ -1,12 +1,17 @@
 package org.mytemplatewizard.project.repository
 
+import com.russhwolf.settings.Settings
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 
 
-class SampleRepositoryImpl() : SampleRepository {
+private const val KEY = "Key"
+
+class SampleRepositoryImpl(
+    private val settings: Settings
+) : SampleRepository {
 
     override fun getIntFlow() = flow {
         var i = 0
@@ -16,4 +21,12 @@ class SampleRepositoryImpl() : SampleRepository {
             delay(1000)
         }
     }.flowOn(Dispatchers.Default)
+
+    override fun setSetting(value: String) {
+        settings.putString(KEY, value)
+    }
+
+    override fun getSettings(): String {
+        return settings.getString(KEY, "")
+    }
 }

--- a/composeApp/src/commonMain/kotlin/org/mytemplatewizard/project/viewmodel/HomePaneViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/mytemplatewizard/project/viewmodel/HomePaneViewModel.kt
@@ -34,6 +34,10 @@ class HomePaneViewModel(
                         sampleInt = history
                     )
                 }
+                println("getSettings: ${   sampleRepository.getSettings()}")
+                if (history > 10) {
+                    sampleRepository.setSetting(history.toString())
+                }
             }
             .flowOn(Dispatchers.Default)
             .launchIn(viewModelScope)

--- a/composeApp/src/desktopMain/kotlin/org/mytemplatewizard/project/di/Modules.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/org/mytemplatewizard/project/di/Modules.desktop.kt
@@ -1,0 +1,14 @@
+package org.mytemplatewizard.project.di
+
+import com.russhwolf.settings.PreferencesSettings
+import com.russhwolf.settings.Settings
+import org.koin.core.module.Module
+import org.koin.dsl.module
+import java.util.prefs.Preferences
+
+actual val platformModule: Module = module {
+    single<Settings> {
+        val preferences = Preferences.userRoot()
+        PreferencesSettings(preferences)
+    }
+}

--- a/composeApp/src/iosMain/kotlin/org/mytemplatewizard/project/di/Modules.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/mytemplatewizard/project/di/Modules.ios.kt
@@ -1,0 +1,13 @@
+package org.mytemplatewizard.project.di
+
+import com.russhwolf.settings.NSUserDefaultsSettings
+import com.russhwolf.settings.Settings
+import org.koin.core.module.Module
+import org.koin.dsl.module
+import platform.Foundation.NSUserDefaults
+
+actual val platformModule: Module = module {
+    single<Settings> {
+        NSUserDefaultsSettings(NSUserDefaults.standardUserDefaults)
+    }
+}

--- a/composeApp/src/wasmJsMain/kotlin/org/mytemplatewizard/project/di/Modules.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/mytemplatewizard/project/di/Modules.wasmJs.kt
@@ -1,0 +1,12 @@
+package org.mytemplatewizard.project.di
+
+import com.russhwolf.settings.Settings
+import com.russhwolf.settings.StorageSettings
+import org.koin.core.module.Module
+import org.koin.dsl.module
+
+actual val platformModule: Module = module {
+    single<Settings> {
+        StorageSettings()
+    }
+}


### PR DESCRIPTION
This commit introduces the `multiplatform-settings` library to enable persistent data storage across Android, iOS, Desktop, and WasmJs platforms.

Key changes:
- Added `com.russhwolf:multiplatform-settings:1.3.0` dependency to `commonMain`.
- Added `androidx.preference:preference:1.2.0` dependency to `androidMain` for SharedPreferences integration.
- Implemented platform-specific `Settings` providers in `Modules.android.kt`, `Modules.ios.kt`, `Modules.desktop.kt`, and `Modules.wasmJs.kt` using `SharedPreferencesSettings`, `NSUserDefaultsSettings`, `PreferencesSettings`, and `StorageSettings` respectively.
- Updated `SampleRepository` and `SampleRepositoryImpl` to include methods for setting and getting string values using the injected `Settings` instance.
- Modified `HomePaneViewModel` to demonstrate saving a value to settings when `sampleInt` exceeds 10 and printing the retrieved setting.
- Uncommented and enabled `platformModule` in `InitKoin.kt` to include platform-specific settings bindings in Koin.
- Injected `Settings` into `SampleRepositoryImpl` via its constructor.